### PR TITLE
Hotfix-HelpsMap

### DIFF
--- a/app/src/store/contexts/helpContext.js
+++ b/app/src/store/contexts/helpContext.js
@@ -30,12 +30,12 @@ export default function HelpContextProvider(props) {
   const [helpList, dispatch] = useReducer(helpReducer, []);
 
   useEffect(() => {
-    if (currentRegion && user) {
+    if (currentRegion && user._id) {
       activeLocations.push(currentRegion);
       getHelpList(currentRegion);
       setupWebSocket();
     }
-  }, [currentRegion]);
+  }, [user._id,currentRegion]);
 
   useEffect(() => {
     subscribeToNewHelps((help) => {


### PR DESCRIPTION
## Descrição 

Foi consertado o erro das ajudas próximas não aparecerem ao usuário logar.

## Tarefas gerais realizadas
* Dentro de helpContext foi alterado um useEffect para observar não só o currentRegion mas também o user_id;
* Com isso o socket e a lista de ajudas são chamados corretamente.
* Foi consertado um erro no qual era chamado a getHelpList antes do usuário logar.
