### PR TITLE
HOTFIX Botões que desaparecem

### DIFF
--- a/app/src/pages/authPages/Address/index.js
+++ b/app/src/pages/authPages/Address/index.js
@@ -67,9 +67,6 @@ export default function Address({ route, navigation }) {
           setCity(localidade);
           setComplement( logradouro + " / " + bairro );
         } else {
-          // alert("CEP não encontrado!");
-          // ToastAndroid.show("CEP não encontrado!", ToastAndroid.BOTTOM)
-
           ToastAndroid.showWithGravityAndOffset(
             "CEP não encontrado!",
             ToastAndroid.LONG,

--- a/app/src/pages/authPages/Address/index.js
+++ b/app/src/pages/authPages/Address/index.js
@@ -6,7 +6,8 @@ import {
   ScrollView,
   Keyboard,
   TouchableOpacity,
-  ActivityIndicator
+  ActivityIndicator,
+  ToastAndroid
 } from "react-native";
 import Input from "../../../components/UI/input";
 import Button from "../../../components/UI/button";
@@ -53,7 +54,7 @@ export default function Address({ route, navigation }) {
         setLoading(true);
         const response = await axios.get(`https://viacep.com.br/ws/${currentCep}/json/`);
 
-        if(!response.data.error) {
+        if(!response.data.erro) {
           const {
             localidade,
             uf,
@@ -66,6 +67,17 @@ export default function Address({ route, navigation }) {
           setCity(localidade);
           setComplement( logradouro + " / " + bairro );
         } else {
+          // alert("CEP não encontrado!");
+          // ToastAndroid.show("CEP não encontrado!", ToastAndroid.BOTTOM)
+
+          ToastAndroid.showWithGravityAndOffset(
+            "CEP não encontrado!",
+            ToastAndroid.LONG,
+            ToastAndroid.CENTER,
+            25,
+            50
+          )
+
           setIsCepValid(false);
         }
 
@@ -74,7 +86,7 @@ export default function Address({ route, navigation }) {
       }
     }
 
-    setLoading(false);
+    setLoading(false);  
   };
 
   const cityHandle = (enteredName) => {

--- a/app/src/pages/authPages/PersonalData/styles.js
+++ b/app/src/pages/authPages/PersonalData/styles.js
@@ -58,6 +58,7 @@ const styles = StyleSheet.create({
     marginVertical: 6,
   },
   toggleView: {
+    marginBottom: 45,
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "flex-start",

--- a/app/src/pages/helpPages/createHelp/index.js
+++ b/app/src/pages/helpPages/createHelp/index.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useContext } from "react";
-import { View, Picker, Text, Modal, ActivityIndicator } from "react-native";
+import { View, Picker, Text, Modal, ActivityIndicator, ScrollView } from "react-native";
 import styles from "./styles";
 import Container from "../../../components/Container";
 import Input from "../../../components/UI/input";
@@ -74,7 +74,7 @@ export default function CreateHelp({ navigation }) {
       });
   }
   return (
-    <View>
+    <ScrollView>
       <Container>
         <View style={styles.view}>
           <View>
@@ -158,6 +158,6 @@ export default function CreateHelp({ navigation }) {
           </Modal>
         </View>
       </View>
-    </View>
+    </ScrollView>
   );
 }


### PR DESCRIPTION
## Descrição 

* Arrumados o botão e checkbox que desapareciam quando o teclado subia nas telas PersonalData e CreateHelp
* Adicionado alerta toast para quando o CEP informado é invalido e modificada a leitura de erro vinda da API

## Resolve (Issues)

[#60](https://github.com/mia-ajuda/Documentation/issues/60)
[#57](https://github.com/mia-ajuda/Documentation/issues/57)
[#74](https://github.com/mia-ajuda/Documentation/issues/74)
[#69](https://github.com/mia-ajuda/Documentation/issues/69)
[#82](https://github.com/mia-ajuda/Documentation/issues/82)
[#83](https://github.com/mia-ajuda/Documentation/issues/83)

## Como testar 

### PersonalData

* Na página inicial clicar em 'Não tem uma conta?'
* Preencher os dados e clicar em continuar
* Clicar em qualquer caixa de texto e verificar que a caixa 'Sou profissional de saúde mental' pode ser acessada por meio de scroll.
* Resultado esperado:

<img src="https://user-images.githubusercontent.com/34405790/82373960-c4243a80-99f4-11ea-9d22-dfe3a80b6e86.png" alt="Screenshot_1589918824" width="250"/>

### CreateHelp

* Na página inicial logar em uma conta
* Clicar em 'Pedir Ajuda'
* Clicar em uma caxa de texto e verificar que o botão 'Preciso de ajuda' pode ser acessado por scroll.
* Resultado esperado:

<img src="https://user-images.githubusercontent.com/34405790/82373994-d30aed00-99f4-11ea-9a7f-e36b1d2fb263.png" alt="Screenshot_1589918801" width="250"/>

### CEP Inválido

* Preencher os dados de criar uma conta até chegar na página de endereço
* Inserir um CEP inexistente
* Verificar que foi mostrado um alerta Toast na tela
* Verificar que nenhum dos campos foi preenchido com 'undefined'
* Resultado esperado:

<img src="https://user-images.githubusercontent.com/34405790/82455792-be2c6900-9a89-11ea-8036-c62735f48618.jpeg" alt="Screenshot" width="250"/>
