### PR TITLE
#66 - Fixing overlay keyboard problem in login page

### DIFF
--- a/app/src/pages/authPages/Login/index.js
+++ b/app/src/pages/authPages/Login/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext, Component } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import {
   View,
   KeyboardAvoidingView,

--- a/app/src/pages/authPages/Login/index.js
+++ b/app/src/pages/authPages/Login/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext } from "react";
+import React, { useState, useEffect, useContext, Component } from "react";
 import {
   View,
   KeyboardAvoidingView,
@@ -14,6 +14,7 @@ import UserService from "../../../services/User";
 import Button from "../../../components/UI/button";
 import { Icon } from "react-native-elements";
 import colors from "../../../../assets/styles/colorVariables";
+
 
 import styles from "./styles";
 import { UserContext } from "../../../store/contexts/userContext";
@@ -127,20 +128,19 @@ export default function Login({ navigation }) {
       });
     }
   };
-
+  
   return (
-    <KeyboardAvoidingView
-      style={styles.container}
-      behavior={Platform.OS === "ios" ? "padding" : null}
-      keyboardVerticalOffset={Platform.OS === "ios" ? 5 : 0}
-    >
+    <View style={styles.container}>
       <View style={styles.logo}>
         <Image
           style={{ flex: 1, resizeMode: "contain", marginTop: 30 }}
           source={require("../../../images/logo.png")}
         />
       </View>
-      <View style={styles.input}>
+      <KeyboardAvoidingView style={styles.input} 
+      behavior={Platform.OS === "ios" ? "padding" : null}
+      keyboardVerticalOffset={Platform.OS === "ios" ? 5 : 0}
+      >
         <TextInput
           keyboardType="email-address"
           style={styles.textInput}
@@ -169,8 +169,7 @@ export default function Login({ navigation }) {
             <Text style={styles.forgotPasswordtext}>Esqueceu a senha?</Text>
           </TouchableOpacity>
         </View>
-      </View>
-
+      </KeyboardAvoidingView>
       <View style={styles.viewBtn}>
         <View style={styles.login}>
           {!loading ? (
@@ -226,6 +225,6 @@ export default function Login({ navigation }) {
           </View>
         </View>
       </View>
-    </KeyboardAvoidingView>
+    </View>
   );
 }

--- a/app/src/pages/authPages/Login/styles.js
+++ b/app/src/pages/authPages/Login/styles.js
@@ -41,6 +41,8 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "flex-start",
     marginTop: 10,
+    marginBottom: 30,
+    flex: 1,
   },
   login: {
     width: "90%",


### PR DESCRIPTION
## Descrição 

Os campos de email e senha na tela de Login ficavam sobrepostos pelo teclado, assim como dito na issue [#66](https://github.com/mia-ajuda/Documentation/issues/66)

## Resolve (Issues)

[#66](https://github.com/mia-ajuda/Documentation/issues/66)

### Emulador testado: Nexus 4 - Tela com 4,7"

![Captura de tela de 2020-05-21 16-16-55](https://user-images.githubusercontent.com/17153869/82598061-6a507b80-9b80-11ea-80a6-2ed8f1d13694.png)
![Captura de tela de 2020-05-21 16-17-17](https://user-images.githubusercontent.com/17153869/82598066-6cb2d580-9b80-11ea-8c48-ab5585ca9bf2.png)

### Celular testado: Moto G6 Plus - Tela com 5,9"

![Screenshot_20200521-152024](https://user-images.githubusercontent.com/17153869/82598094-750b1080-9b80-11ea-90f5-5afd95f91be4.png)
![Screenshot_20200521-152031](https://user-images.githubusercontent.com/17153869/82598096-76d4d400-9b80-11ea-9be9-d53447c340d0.png)

