### PR TITLE
Handling error when trying to authenticate too many times

### DIFF
--- a/app/src/utils/translateFirebaseAuthError.js
+++ b/app/src/utils/translateFirebaseAuthError.js
@@ -1,7 +1,10 @@
 const errorMessages = {
-  "auth/user-not-found": "O email fornecido não foi encontrado.",
-  "auth/wrong-password": "A senha fornecida é inválida.",
-  "auth/invalid-email": "O email fornecido está inválido.",
+  "auth/user-not-found": "Email não encontrado.",
+  "auth/wrong-password": "Senha inválida.",
+  "auth/invalid-email": "Email inválido.",
+  "auth/too-many-requests":
+    "Foram feitas muitas tentativas de login com esse email. Tente novamente mais tarde.",
+  " auth/invalid-password": "Senha inválida.",
 };
 
 export default errorMessages;


### PR DESCRIPTION
## Descrição 

Foi reportado que ao tentar fazer diversas requisições, é mostrado uma mensagem de erro nada amigável. Esse pr trata o erro para que a mensagem de erro para esse caso seja mais descritiva. 
![image](https://user-images.githubusercontent.com/37307099/84970655-839e0680-b0f1-11ea-8eb0-ebc6669ec777.png)
![image](https://user-images.githubusercontent.com/37307099/84970664-8993e780-b0f1-11ea-8911-d0c1b8867d64.png)


## Tarefas gerais realizadas
* Mapeamento do código de erro retornado pelo firebase e sua tradução para o português
* Melhoria das demais mensagens de erro. 
