### PR TITLE
Alterações nas páginas Adress, RiskGroup e CreateHelp 

### DIFF
--- a/app/src/pages/authPages/Address/index.js~Stashed changes
+++ b/app/src/pages/authPages/Address/index.js~Stashed changes
@@ -1,0 +1,175 @@
+import React, { useState, useEffect, useContext } from 'react';
+import {
+    View,
+    KeyboardAvoidingView,
+    Text,
+    ScrollView,
+    TouchableOpacity,
+    ActivityIndicator,
+} from 'react-native';
+import ToastMessage from '../../../utils/ToastAndroid';
+import Input from '../../../components/UI/input';
+import Button from '../../../components/UI/button';
+import styles from './styles';
+import { Icon } from 'react-native-elements';
+import ViaCep from '../../../services/ExternalServices/ViaCep';
+import colors from '../../../../assets/styles/colorVariables';
+import { DeviceInformationContext } from '../../../store/contexts/deviceInformationContext';
+
+export default function Address({ route, navigation }) {
+    const { keyboard } = useContext(DeviceInformationContext);
+    const { userDataFromPersonalPage } = route.params;
+
+    const [cep, setCep] = useState('');
+    const [isCepValid, setCepValid] = useState(true);
+    const [city, setCity] = useState('');
+    const [uf, setUf] = useState('');
+    const [complement, setComplement] = useState('');
+    const [numberPlace, setNumberPlace] = useState('');
+    const [isCepRequestLoading, setCepRequestLoading] = useState(false);
+
+    useEffect(() => {
+        const shouldResquestCepInformation = cep.length === 8;
+        if (shouldResquestCepInformation) {
+            getCepInformation(cep);
+        }
+    }, [cep]);
+
+    async function getCepInformation(currentCep) {
+        keyboard.dismiss();
+        try {
+            setCepRequestLoading(true);
+            const cepInformation = await ViaCep.getCepInformation(currentCep);
+            const { bairro, localidade, logradouro, uf } = cepInformation;
+
+            setUf(uf);
+            setCity(localidade);
+            setComplement(`${logradouro}/${bairro}`);
+            setCepValid(true);
+        } catch (error) {
+            setCepValid(false);
+            ToastMessage(
+                error.message || 'Não foi possível recuperar este cep',
+            );
+        } finally {
+            setCepRequestLoading(false);
+        }
+    }
+
+    const renderPageDescription = () => {
+        if (keyboard.visible === false) {
+            return (
+                <Text style={styles.pageDescription}>
+                    Precisamos de algumas informações sobre onde você mora. Por
+                    favor, preencha as informações abaixo.
+                </Text>
+            );
+        }
+    };
+    const renderLoadingIndicator = () => (
+        <View style={styles.loadingIndicator}>
+            <ActivityIndicator size="large" color={colors.primary} />
+        </View>
+    );
+
+    const renderRegistrationForm = () => (
+        <View style={styles.inputView}>
+            <Input
+                change={(cep) => setCep(cep)}
+                label="CEP"
+                placeholder="Digite seu CEP"
+                value={cep}
+                keyboard="numeric"
+                maxLength={8}
+                valid={isCepValid}
+            />
+            <View style={styles.viewMargin}></View>
+            <Input
+                change={(city) => setCity(city)}
+                value={city}
+                label="Cidade"
+                placeholder="Digite sua cidade"
+            />
+            <View style={styles.viewMargin}></View>
+            <Input
+                change={(uf) => setUf(uf)}
+                value={uf}
+                label="UF"
+                placeholder="UF"
+                maxLength={2}
+            />
+            <View style={styles.viewMargin}></View>
+            <Input
+                change={(number) => setNumberPlace(number)}
+                label="Número"
+                placeholder="Digite o número de sua residência"
+                value={numberPlace}
+                keyboard="numeric"
+            />
+            <View style={styles.viewMargin}></View>
+            <Input
+                change={(complement) => setComplement(complement)}
+                label="Complemento"
+                value={complement}
+                placeholder="Opcional"
+            />
+            <View style={styles.viewMargin}></View>
+        </View>
+    );
+
+    const renderContinueButton = () => {
+        const disableButton =
+            cep.length == 0 ||
+            city.length == 0 ||
+            uf.length == 0 ||
+            numberPlace.length == 0;
+
+        return (
+            <View style={styles.btnView}>
+                <Button
+                    title="Continuar"
+                    disabled={disableButton}
+                    large
+                    press={continueButtonPressed}
+                />
+            </View>
+        );
+    };
+
+    const continueButtonPressed = () => {
+        const address = {
+            cep,
+            city,
+            state: uf,
+            number: numberPlace,
+            complement,
+        };
+        const userDataFromAddressPage = {
+            address,
+            ...userDataFromPersonalPage,
+        };
+        navigation.navigate('photo', { userDataFromAddressPage });
+    };
+
+    return (
+        <KeyboardAvoidingView style={styles.container} behavior='padding'>
+            <ScrollView
+                style={styles.scroll}
+                contentContainerStyle={styles.scrollContainer}>
+                <View style={styles.backIcon}>
+                    <TouchableOpacity onPress={() => navigation.goBack()}>
+                        <Icon name={'arrow-back'} color={'black'} />
+                    </TouchableOpacity>
+                </View>
+
+                {renderPageDescription()}
+
+                {isCepRequestLoading
+                    ? renderLoadingIndicator()
+                    : renderRegistrationForm()}
+            </ScrollView>
+
+            {renderContinueButton()}
+        </KeyboardAvoidingView>
+    );
+}

--- a/app/src/pages/authPages/RiskGroup/index.js
+++ b/app/src/pages/authPages/RiskGroup/index.js
@@ -86,7 +86,11 @@ export default function RiskGroup({ route, navigation }) {
                 {loading ? (
                     <ActivityIndicator size="large" color={colors.primary} />
                 ) : (
-                    <Button title="Concluir" large press={confirmSignUp} />
+                    <Button 
+                    title="Concluir" 
+                    disabled={false}
+                    large 
+                    press={confirmSignUp} />
                 )}
             </View>
         </View>

--- a/app/src/pages/authPages/RiskGroup/styles.js
+++ b/app/src/pages/authPages/RiskGroup/styles.js
@@ -28,6 +28,7 @@ const styles = StyleSheet.create({
     btnView: {
         width: '90%',
         bottom: 20,
+        backgroundColor: colors.primary,
         justifyContent: 'flex-end',
         position: 'absolute',
     },

--- a/app/src/pages/helpPages/createHelp/index.js~Stashed changes
+++ b/app/src/pages/helpPages/createHelp/index.js~Stashed changes
@@ -1,0 +1,149 @@
+import React, { useState, useEffect, useContext } from 'react';
+import {
+    View,
+    Picker,
+    Text,
+    ActivityIndicator,
+    ScrollView,
+} from 'react-native';
+import styles from './styles';
+import Container from '../../../components/Container';
+import Input from '../../../components/UI/input';
+import Button from '../../../components/UI/button';
+import colors from '../../../../assets/styles/colorVariables';
+import { CategoryContext } from '../../../store/contexts/categoryContext';
+
+import NewHelpModalSuccess from '../../../components/modals/newHelpModal/success';
+import NewHelpModalError from '../../../components/modals/newHelpModal/failure';
+
+import helpService from '../../../services/Help';
+import { UserContext } from '../../../store/contexts/userContext';
+
+import showWarningFor from '../../../utils/warningPopUp';
+import { requestHelpWarningMessage } from '../../../docs/warning';
+
+export default function CreateHelp({ navigation }) {
+    const [title, setTitle] = useState('');
+    const [category, setCategory] = useState({});
+    const [description, setDescription] = useState('');
+    const [buttonDisabled, setButtonDisabled] = useState(true);
+    const [modalSuccessModalVisible, setModalSuccessMoldalVisible] = useState(
+        false,
+    );
+    const [modalErrorModalVisible, setErrorModalVisible] = useState(false);
+    const [createHelpLoading, setCreateHelpLoading] = useState(false);
+    const [limitErrorMessage, setLimitErrorMessage] = useState(null);
+
+    const { categories } = useContext(CategoryContext);
+    const { user } = useContext(UserContext);
+
+    useEffect(() => {
+        showWarningFor('helpRequest', requestHelpWarningMessage);
+    }, []);
+
+    useEffect(() => {
+        if (title && category && description) {
+            setButtonDisabled(false);
+        } else {
+            setButtonDisabled(true);
+        }
+    }, [title, description, category]);
+
+    async function createHelp() {
+        const { _id: userId } = user;
+        try {
+            setCreateHelpLoading(true);
+            await helpService.createHelp(
+                title,
+                category['_id'],
+                description,
+                userId,
+            );
+            setModalSuccessMoldalVisible(true);
+        } catch (error) {
+            const errorMessage = error.response.data.error;
+            if (errorMessage && errorMessage.includes('Limite máximo')) {
+                setLimitErrorMessage(errorMessage);
+            }
+            setErrorModalVisible(true);
+        } finally {
+            setCreateHelpLoading(false);
+        }
+    }
+
+    const renderPickerCategoryForm = () => (
+        <View style={styles.catagoryPicker}>
+            <Text style={styles.label}>Categoria</Text>
+            <View style={styles.picker}>
+                <Picker
+                    label="Categoria"
+                    selectedValue={category}
+                    onValueChange={(itemValue) => setCategory(itemValue)}>
+                    <Text style={styles.label}>Escolha uma Categoria</Text>
+                    {categories.map((category) => (
+                        <Picker.itemValue  style={styles.picker}
+                            key={category._id}
+                            color={colors.dark}
+                            label={category.name}
+                            value={category}
+                        />
+                    ))}
+                </Picker>
+            </View>
+        </View>
+    );
+
+    const renderInputDescriptionForm = () => (
+        <View style={styles.descriptionInput}>
+            <Input
+                label="Descrição"
+                textarea
+                change={(text) => setDescription(text)}
+            />
+            <Text>{description.length}/300</Text>
+        </View>
+    );
+
+    const renderInputTitleForm = () => (
+        <Input label="Título" change={(text) => setTitle(text)} />
+    );
+    const renderLoadingIdicator = () => (
+        <ActivityIndicator size="large" color={colors.primary} />
+    );
+
+    const createHelpBtn = () => (
+        <Button
+            title="Preciso de ajuda"
+            large
+            disabled={buttonDisabled}
+            press={createHelp}
+        />
+    );
+
+    return (
+        <ScrollView>
+            <Container>
+                <View style={styles.view}>
+                    {renderInputTitleForm()}
+                    {renderPickerCategoryForm()}
+                    {renderInputDescriptionForm()}
+
+                    <View style={styles.btnContainer}>
+                        {createHelpLoading
+                            ? renderLoadingIdicator()
+                            : createHelpBtn()}
+                    </View>
+                </View>
+            </Container>
+            <NewHelpModalSuccess
+                visible={modalSuccessModalVisible}
+                onOkPressed={() => navigation.navigate('main')}
+            />
+            <NewHelpModalError
+                visible={modalErrorModalVisible}
+                onOkPressed={() => navigation.navigate('main')}
+                errorMessage={limitErrorMessage}
+            />
+        </ScrollView>
+    );
+}


### PR DESCRIPTION
 
PR referente às issues M07, M08, M09
M07- Na tela de cadastro do endereço o botão Continuar é sobreposto pelo teclado quando usuário vai preencher o Número
M08-O botão Continuar em grupo de risco se apresenta fosco ou "desativado", caso o usuário não selecione nenhuma opção, dando a entender que ele não pode continuar com o cadastro caso ele não selecione algo.
M09-Em criar ajuda, existe uma lacuna em branco onde poderia estar escrito "Escolha uma categoria", ou poderia ser melhorado a formatação do design.

