### PR TITLE
M06 - Teclado sobrepondo botão de Continuar. #146

### DIFF
--- a/app/src/pages/AuthPages/PersonalData/index.js
+++ b/app/src/pages/AuthPages/PersonalData/index.js
@@ -206,7 +206,7 @@ export default function PersonalData({ route, navigation }) {
     };
 
     return (
-        <KeyboardAvoidingView style={styles.container} behavior="height">
+        <KeyboardAvoidingView style={styles.container} behavior="padding">
             {renderPageHeader()}
             <ScrollView
                 style={styles.formScroll}


### PR DESCRIPTION
## Descrição 

Na tela de dados pessoais o botão Continuar é sobreposto pelo teclado quando o usuário vai preencher qualquer um dos campos.

## Resolve (Issues)

Foi acrescentada a propriedade correta para esse caso.

Issues que foram resolvidas com o PR

## Tarefas gerais realizadas
* Atualização da propriedade do keybord

