### PR TITLE
[Feature] Help Categories

### DIFF
--- a/app/assets/fonts/loadFonts.js
+++ b/app/assets/fonts/loadFonts.js
@@ -1,10 +1,10 @@
-import * as Font from "expo-font";
+import * as Font from 'expo-font';
 
 export default async function loadFonts() {
-  return Font.loadAsync({
-    "montserrat-light": require("../fonts/Montserrat/Montserrat-Light.ttf"),
-    "montserrat-regular": require("../fonts/Montserrat/Montserrat-Regular.ttf"),
-    "montserrat-medium": require("../fonts/Montserrat/Montserrat-Medium.ttf"),
-    "montserrat-semibold": require("../fonts/Montserrat/Montserrat-SemiBold.ttf")
-  });
+    return Font.loadAsync({
+        'montserrat-light': require('../fonts/Montserrat/Montserrat-Light.ttf'),
+        'montserrat-regular': require('../fonts/Montserrat/Montserrat-Regular.ttf'),
+        'montserrat-medium': require('../fonts/Montserrat/Montserrat-Medium.ttf'),
+        'montserrat-semibold': require('../fonts/Montserrat/Montserrat-SemiBold.ttf'),
+    });
 }

--- a/app/src/components/HelpCard/index.js
+++ b/app/src/components/HelpCard/index.js
@@ -19,7 +19,7 @@ export default function HelpCard({ help, isRiskGroup, children }) {
                 <Text numberOfLines={3} style={styles.descriptionContent}>
                     {help.description}
                 </Text>
-                {/* <View style={styles.bottomItens}>
+                <View style={styles.bottomItens}>
                     <View style={styles.categoryContainer}>
                         {help.categories.map((category) => (
                             <View
@@ -31,7 +31,7 @@ export default function HelpCard({ help, isRiskGroup, children }) {
                             </View>
                         ))}
                     </View>
-                </View> */}
+                </View>
             </View>
             {children}
         </View>

--- a/app/src/components/HelpCard/index.js
+++ b/app/src/components/HelpCard/index.js
@@ -19,13 +19,19 @@ export default function HelpCard({ help, isRiskGroup, children }) {
                 <Text numberOfLines={3} style={styles.descriptionContent}>
                     {help.description}
                 </Text>
-                <View style={styles.bottomItens}>
-                    <View style={styles.categoryWarning}>
-                        <Text style={styles.categoryName}>
-                            {help.category[0].name}
-                        </Text>
+                {/* <View style={styles.bottomItens}>
+                    <View style={styles.categoryContainer}>
+                        {help.categories.map((category) => (
+                            <View
+                                key={category._id}
+                                style={styles.categoryWarning}>
+                                <Text style={styles.categoryName}>
+                                    {category.name}
+                                </Text>
+                            </View>
+                        ))}
                     </View>
-                </View>
+                </View> */}
             </View>
             {children}
         </View>

--- a/app/src/components/HelpCard/styles.js
+++ b/app/src/components/HelpCard/styles.js
@@ -8,7 +8,6 @@ const cardContainerStyle = {
     maxHeight: 240,
     marginTop: 20,
     borderWidth: 1,
-    height: 120,
     backgroundColor: colors.light,
     borderRadius: 8,
     alignItems: 'flex-start',
@@ -49,7 +48,7 @@ export default StyleSheet.create({
 
     descriptionContent: {
         ...fonts.body,
-        fontSize: 16,
+        fontSize: 12,
 
         color: colors.dark,
     },
@@ -60,8 +59,9 @@ export default StyleSheet.create({
 
         maxHeight: 30,
 
-        paddingHorizontal: 15,
-        marginLeft: 5,
+        paddingHorizontal: 10,
+        marginRight: 5,
+        marginTop: 5,
         alignSelf: 'flex-start',
     },
 
@@ -70,6 +70,7 @@ export default StyleSheet.create({
         fontFamily: 'montserrat-semibold',
         lineHeight: 30,
         textAlign: 'center',
+        fontSize: 12,
     },
 
     bottomItens: {

--- a/app/src/components/HelpCard/styles.js
+++ b/app/src/components/HelpCard/styles.js
@@ -8,9 +8,9 @@ const cardContainerStyle = {
     maxHeight: 240,
     marginTop: 20,
     borderWidth: 1,
+    height: 120,
     backgroundColor: colors.light,
     borderRadius: 8,
-    justifyContent: 'center',
     alignItems: 'flex-start',
     paddingLeft: 20,
     paddingRight: 20,
@@ -32,11 +32,6 @@ export default StyleSheet.create({
         ...cardContainerStyle,
     },
 
-    cardTitle: {
-        maxWidth: '100%',
-        maxHeight: '30%',
-    },
-
     titleContent: {
         ...fonts.title,
         fontFamily: 'montserrat-semibold',
@@ -48,19 +43,14 @@ export default StyleSheet.create({
 
     cardDescription: {
         marginTop: 5,
-        maxWidth: '100%',
-        maxHeight: '70%',
-
         alignItems: 'flex-start',
         justifyContent: 'center',
     },
 
     descriptionContent: {
-        fontStyle: 'normal',
-        fontWeight: 'normal',
-        fontSize: 12,
+        ...fonts.body,
+        fontSize: 16,
 
-        lineHeight: 14,
         color: colors.dark,
     },
 
@@ -71,7 +61,7 @@ export default StyleSheet.create({
         maxHeight: 30,
 
         paddingHorizontal: 15,
-
+        marginLeft: 5,
         alignSelf: 'flex-start',
     },
 
@@ -88,5 +78,10 @@ export default StyleSheet.create({
         flexDirection: 'row',
         justifyContent: 'space-between',
         alignItems: 'center',
+    },
+    categoryContainer: {
+        flexDirection: 'row',
+        width: '100%',
+        flexWrap: 'wrap',
     },
 });

--- a/app/src/components/SelectCategoryForm/index.js
+++ b/app/src/components/SelectCategoryForm/index.js
@@ -1,0 +1,65 @@
+import React, { useState, useContext } from 'react';
+import { View, TouchableOpacity, Text } from 'react-native';
+import CategorySelector from '../modals/category/CategorySelector';
+import { CategoryContext } from '../../store/contexts/categoryContext';
+import colors from '../../../assets/styles/colorVariables';
+import styles from './styles';
+
+export default function SelectCategoryForm({
+    helpCategoryIds,
+    setHelpCategoryIds,
+}) {
+    const [categoryModalVisible, setCategoryModalVisible] = useState(false);
+    const { categories } = useContext(CategoryContext);
+    const openCategoryModal = () => setCategoryModalVisible(true);
+    const hideCategoryModal = () => setCategoryModalVisible(false);
+
+    const renderPickerCategoryForm = () => (
+        <TouchableOpacity
+            style={styles.addCategory}
+            onPress={openCategoryModal}>
+            <Text style={styles.addCategoryText}>Categorias +</Text>
+        </TouchableOpacity>
+    );
+
+    const renderSelectedCategories = () => {
+        return (
+            <View
+                style={{
+                    flexDirection: 'row',
+                    flexWrap: 'wrap',
+                    marginTop: 10,
+                }}>
+                {categories.map((category) => {
+                    if (helpCategoryIds.includes(category._id)) {
+                        return (
+                            <Text
+                                style={{
+                                    backgroundColor: colors.secondary,
+                                    padding: 5,
+                                    elevation: 2,
+                                    margin: 5,
+                                    borderRadius: 2,
+                                }}>
+                                {category.name}
+                            </Text>
+                        );
+                    }
+                })}
+            </View>
+        );
+    };
+    return (
+        <View>
+            <CategorySelector
+                modalVisible={categoryModalVisible}
+                openModal={openCategoryModal}
+                hideModal={hideCategoryModal}
+                setHelpCategoryIds={setHelpCategoryIds}
+                categoryIds={helpCategoryIds}
+            />
+            {renderPickerCategoryForm()}
+            {renderSelectedCategories()}
+        </View>
+    );
+}

--- a/app/src/components/SelectCategoryForm/index.js
+++ b/app/src/components/SelectCategoryForm/index.js
@@ -1,12 +1,13 @@
 import React, { useState, useContext } from 'react';
 import { View, TouchableOpacity, Text } from 'react-native';
-import CategorySelector from '../modals/category/CategorySelector';
+import CategorySelectorModal from '../modals/category/CategorySelector';
 import { CategoryContext } from '../../store/contexts/categoryContext';
 import styles from './styles';
 
 export default function SelectCategoryForm({
     helpCategoryIds,
     setHelpCategoryIds,
+    helpType,
 }) {
     const [categoryModalVisible, setCategoryModalVisible] = useState(false);
     const { categories } = useContext(CategoryContext);
@@ -40,12 +41,13 @@ export default function SelectCategoryForm({
     };
     return (
         <View>
-            <CategorySelector
+            <CategorySelectorModal
                 modalVisible={categoryModalVisible}
                 openModal={openCategoryModal}
                 hideModal={hideCategoryModal}
-                setHelpCategoryIds={setHelpCategoryIds}
-                categoryIds={helpCategoryIds}
+                setHelpSelectedCategoryIds={setHelpCategoryIds}
+                selectedCategoryIds={helpCategoryIds}
+                helpCreationType={helpType}
             />
             {renderPickerCategoryForm()}
             {renderSelectedCategories()}

--- a/app/src/components/SelectCategoryForm/styles.js
+++ b/app/src/components/SelectCategoryForm/styles.js
@@ -1,0 +1,23 @@
+import { StyleSheet } from 'react-native';
+import fonts from '../../../assets/styles/fontVariable';
+import colors from '../../../assets/styles/colorVariables';
+const styles = StyleSheet.create({
+    addCategory: {
+        backgroundColor: colors.primary,
+        borderWidth: 1,
+        borderColor: colors.primary,
+        padding: 5,
+        marginTop: 20,
+        width: '40%',
+        borderRadius: 5,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    addCategoryText: {
+        ...fonts.body,
+        color: '#fff',
+        fontSize: 18,
+    },
+});
+
+export default styles;

--- a/app/src/components/UI/button/styles.js
+++ b/app/src/components/UI/button/styles.js
@@ -31,7 +31,6 @@ const styles = StyleSheet.create({
         ...btn,
         backgroundColor: colors.primary,
         borderColor: colors.primary,
-        borderWidth: 2,
     },
     textDisabled: { ...text, color: '#666' },
     btnDisabled: {

--- a/app/src/components/modals/category/CategorySelector/index.js
+++ b/app/src/components/modals/category/CategorySelector/index.js
@@ -109,7 +109,7 @@ export default function CategorySelector({
                         {renderModalTitle()}
                         {renderCategoryList()}
                         <Button
-                            title="concluir"
+                            title="Concluir"
                             large
                             type="warning"
                             press={hideModal}

--- a/app/src/components/modals/category/CategorySelector/index.js
+++ b/app/src/components/modals/category/CategorySelector/index.js
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext } from 'react';
 import {
     View,
     Modal,
@@ -14,32 +14,36 @@ import Button from '../../../UI/button';
 import { ScrollView } from 'react-native-gesture-handler';
 import styles from './styles';
 
-export default function CategorySelector({ modalVisible, setModalVisible }) {
+export default function CategorySelector({
+    modalVisible,
+    hideModal,
+    setHelpCategoryIds,
+    categoryIds,
+}) {
     const { categories } = useContext(CategoryContext);
-    const [selectedCategoriesId, setSelectedCategoriesId] = useState([]);
 
     const includeCategoryIntoSelectedCategories = (categoryId) =>
-        setSelectedCategoriesId([...selectedCategoriesId, categoryId]);
+        setHelpCategoryIds([...categoryIds, categoryId]);
 
     const removeCategoryFromSelectedCategories = (categoryId) => {
-        const removeCategoryId = selectedCategoriesId.filter(
+        const removeCategoryId = categoryIds.filter(
             (categoryIdFromState) => categoryIdFromState !== categoryId,
         );
-        setSelectedCategoriesId(removeCategoryId);
+        setHelpCategoryIds(removeCategoryId);
     };
 
     const selectCategory = (categoryId) => {
-        if (selectedCategoriesId.includes(categoryId)) {
+        if (categoryIds.includes(categoryId)) {
             removeCategoryFromSelectedCategories(categoryId);
-        } else if (selectedCategoriesId.length < 3) {
+        } else if (categoryIds.length < 3) {
             includeCategoryIntoSelectedCategories(categoryId);
         }
     };
 
     const getCategoryStyle = (categoryId) => {
-        if (selectedCategoriesId.includes(categoryId)) {
+        if (categoryIds.includes(categoryId)) {
             return styles.selectedCategory;
-        } else if (selectedCategoriesId.length >= 3) {
+        } else if (categoryIds.length >= 3) {
             return styles.unvailableToSelectCategory;
         } else {
             return styles.notSelectedCategory;
@@ -47,10 +51,7 @@ export default function CategorySelector({ modalVisible, setModalVisible }) {
     };
 
     const getCategoryActiveOpacity = (categoryId) => {
-        if (
-            selectedCategoriesId.includes(categoryId) ||
-            selectedCategoriesId.length < 3
-        ) {
+        if (categoryIds.includes(categoryId) || categoryIds.length < 3) {
             return 0;
         } else {
             return 1;
@@ -58,9 +59,7 @@ export default function CategorySelector({ modalVisible, setModalVisible }) {
     };
 
     const renderCloseButton = () => (
-        <TouchableOpacity
-            style={styles.closeButton}
-            onPress={() => setModalVisible(false)}>
+        <TouchableOpacity style={styles.closeButton} onPress={hideModal}>
             <Icon
                 name="times-circle"
                 type="font-awesome"
@@ -98,14 +97,23 @@ export default function CategorySelector({ modalVisible, setModalVisible }) {
         <Modal
             visible={modalVisible}
             transparent
-            onRequestClose={() => setModalVisible(false)}>
-            <TouchableOpacity style={styles.container} activeOpacity={1}>
+            onRequestClose={hideModal}
+            animationType="fade">
+            <TouchableOpacity
+                style={styles.container}
+                activeOpacity={1}
+                onPress={hideModal}>
                 <TouchableWithoutFeedback>
                     <View style={styles.content}>
                         {renderCloseButton()}
                         {renderModalTitle()}
                         {renderCategoryList()}
-                        <Button title="concluir" large type="warning" />
+                        <Button
+                            title="concluir"
+                            large
+                            type="warning"
+                            press={hideModal}
+                        />
                     </View>
                 </TouchableWithoutFeedback>
             </TouchableOpacity>

--- a/app/src/components/modals/category/CategorySelector/index.js
+++ b/app/src/components/modals/category/CategorySelector/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View } from 'react-native';
+
+// import { Container } from './styles';
+
+const CategorySelector = () => {
+    return <View />;
+};
+
+export default CategorySelector;

--- a/app/src/components/modals/category/CategorySelector/index.js
+++ b/app/src/components/modals/category/CategorySelector/index.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState, useEffect } from 'react';
 import {
     View,
     Modal,
@@ -7,6 +7,7 @@ import {
     TouchableWithoutFeedback,
 } from 'react-native';
 import { CategoryContext } from '../../../../store/contexts/categoryContext';
+import { UserContext } from '../../../../store/contexts/userContext';
 import { Icon } from 'react-native-elements';
 import colors from '../../../../../assets/styles/colorVariables';
 
@@ -17,33 +18,40 @@ import styles from './styles';
 export default function CategorySelector({
     modalVisible,
     hideModal,
-    setHelpCategoryIds,
-    categoryIds,
+    setHelpSelectedCategoryIds,
+    selectedCategoryIds,
+    helpCreationType,
 }) {
+    const [categoriesByUser, setCategoriesByUser] = useState([]);
     const { categories } = useContext(CategoryContext);
+    const { user } = useContext(UserContext);
+
+    useEffect(() => {
+        filterCategoriesByUser();
+    }, []);
 
     const includeCategoryIntoSelectedCategories = (categoryId) =>
-        setHelpCategoryIds([...categoryIds, categoryId]);
+        setHelpSelectedCategoryIds([...selectedCategoryIds, categoryId]);
 
     const removeCategoryFromSelectedCategories = (categoryId) => {
-        const removeCategoryId = categoryIds.filter(
+        const removeCategoryId = selectedCategoryIds.filter(
             (categoryIdFromState) => categoryIdFromState !== categoryId,
         );
-        setHelpCategoryIds(removeCategoryId);
+        setHelpSelectedCategoryIds(removeCategoryId);
     };
 
     const selectCategory = (categoryId) => {
-        if (categoryIds.includes(categoryId)) {
+        if (selectedCategoryIds.includes(categoryId)) {
             removeCategoryFromSelectedCategories(categoryId);
-        } else if (categoryIds.length < 3) {
+        } else if (selectedCategoryIds.length < 3) {
             includeCategoryIntoSelectedCategories(categoryId);
         }
     };
 
     const getCategoryStyle = (categoryId) => {
-        if (categoryIds.includes(categoryId)) {
+        if (selectedCategoryIds.includes(categoryId)) {
             return styles.selectedCategory;
-        } else if (categoryIds.length >= 3) {
+        } else if (selectedCategoryIds.length >= 3) {
             return styles.unvailableToSelectCategory;
         } else {
             return styles.notSelectedCategory;
@@ -51,7 +59,10 @@ export default function CategorySelector({
     };
 
     const getCategoryActiveOpacity = (categoryId) => {
-        if (categoryIds.includes(categoryId) || categoryIds.length < 3) {
+        if (
+            selectedCategoryIds.includes(categoryId) ||
+            selectedCategoryIds.length < 3
+        ) {
             return 0;
         } else {
             return 1;
@@ -76,20 +87,40 @@ export default function CategorySelector({
         </>
     );
 
+    const removePsychologicalSupportFromCategories = () => {
+        return categories.filter(
+            (category) => category.name !== 'Apoio Psicológico',
+        );
+    };
+    const filterCategoriesByUser = () => {
+        let categoriesToList;
+        if (
+            helpCreationType == 'offer' &&
+            user.ismentalHealthProfessional == false
+        ) {
+            categoriesToList = removePsychologicalSupportFromCategories();
+        } else {
+            categoriesToList = categories;
+        }
+        setCategoriesByUser(categoriesToList);
+    };
+
     const renderCategoryList = () => (
         <ScrollView showsVerticalScrollIndicator={false}>
-            {categories?.map((category) => (
-                <TouchableOpacity
-                    activeOpacity={getCategoryActiveOpacity(category._id)}
-                    key={category._id}
-                    onPress={() => {
-                        selectCategory(category._id);
-                    }}>
-                    <Text style={getCategoryStyle(category._id)}>
-                        {category.name}
-                    </Text>
-                </TouchableOpacity>
-            ))}
+            {categoriesByUser?.map((category) => {
+                return (
+                    <TouchableOpacity
+                        activeOpacity={getCategoryActiveOpacity(category._id)}
+                        key={category._id}
+                        onPress={() => {
+                            selectCategory(category._id);
+                        }}>
+                        <Text style={getCategoryStyle(category._id)}>
+                            {category.name}
+                        </Text>
+                    </TouchableOpacity>
+                );
+            })}
         </ScrollView>
     );
 

--- a/app/src/components/modals/category/CategorySelector/index.js
+++ b/app/src/components/modals/category/CategorySelector/index.js
@@ -1,10 +1,64 @@
-import React from 'react';
-import { View } from 'react-native';
+import React, { useContext, useState } from 'react';
+import {
+    View,
+    Modal,
+    Text,
+    TouchableOpacity,
+    TouchableWithoutFeedback,
+} from 'react-native';
+import { CategoryContext } from '../../../../store/contexts/categoryContext';
 
-// import { Container } from './styles';
+import Button from '../../../UI/button';
+import { ScrollView } from 'react-native-gesture-handler';
+import styles from './styles';
 
-const CategorySelector = () => {
-    return <View />;
-};
+export default function CategorySelector() {
+    const { categories } = useContext(CategoryContext);
+    const [selectedCategoriesId, setSelectedCategoriesId] = useState([]);
 
-export default CategorySelector;
+    const selectCategory = (categoryId) =>
+        setSelectedCategoriesId([...selectedCategoriesId, categoryId]);
+    const removeCategory = (categoryId) => {
+        const removeCategoryId = selectedCategoriesId.filter(
+            (categoryIdFromState) => categoryIdFromState !== categoryId,
+        );
+        setSelectedCategoriesId(removeCategoryId);
+    };
+
+    return (
+        <Modal visible transparent>
+            <TouchableOpacity style={styles.container}>
+                <TouchableWithoutFeedback>
+                    <View style={styles.content}>
+                        <Text style={styles.title}>Escolha as categorias</Text>
+                        <ScrollView showsVerticalScrollIndicator={false}>
+                            {categories?.map((category) => (
+                                <TouchableOpacity
+                                    key={category._id}
+                                    onPress={() => {
+                                        selectedCategoriesId.includes(
+                                            category._id,
+                                        )
+                                            ? removeCategory(category._id)
+                                            : selectCategory(category._id);
+                                    }}>
+                                    <Text
+                                        style={
+                                            selectedCategoriesId.includes(
+                                                category._id,
+                                            )
+                                                ? styles.selectedCategory
+                                                : styles.notSelectedCategory
+                                        }>
+                                        {category.name}
+                                    </Text>
+                                </TouchableOpacity>
+                            ))}
+                        </ScrollView>
+                        <Button title="concluir" large type="warning" />
+                    </View>
+                </TouchableWithoutFeedback>
+            </TouchableOpacity>
+        </Modal>
+    );
+}

--- a/app/src/components/modals/category/CategorySelector/index.js
+++ b/app/src/components/modals/category/CategorySelector/index.js
@@ -7,54 +7,104 @@ import {
     TouchableWithoutFeedback,
 } from 'react-native';
 import { CategoryContext } from '../../../../store/contexts/categoryContext';
+import { Icon } from 'react-native-elements';
+import colors from '../../../../../assets/styles/colorVariables';
 
 import Button from '../../../UI/button';
 import { ScrollView } from 'react-native-gesture-handler';
 import styles from './styles';
 
-export default function CategorySelector() {
+export default function CategorySelector({ modalVisible, setModalVisible }) {
     const { categories } = useContext(CategoryContext);
     const [selectedCategoriesId, setSelectedCategoriesId] = useState([]);
 
-    const selectCategory = (categoryId) =>
+    const includeCategoryIntoSelectedCategories = (categoryId) =>
         setSelectedCategoriesId([...selectedCategoriesId, categoryId]);
-    const removeCategory = (categoryId) => {
+
+    const removeCategoryFromSelectedCategories = (categoryId) => {
         const removeCategoryId = selectedCategoriesId.filter(
             (categoryIdFromState) => categoryIdFromState !== categoryId,
         );
         setSelectedCategoriesId(removeCategoryId);
     };
 
+    const selectCategory = (categoryId) => {
+        if (selectedCategoriesId.includes(categoryId)) {
+            removeCategoryFromSelectedCategories(categoryId);
+        } else if (selectedCategoriesId.length < 3) {
+            includeCategoryIntoSelectedCategories(categoryId);
+        }
+    };
+
+    const getCategoryStyle = (categoryId) => {
+        if (selectedCategoriesId.includes(categoryId)) {
+            return styles.selectedCategory;
+        } else if (selectedCategoriesId.length >= 3) {
+            return styles.unvailableToSelectCategory;
+        } else {
+            return styles.notSelectedCategory;
+        }
+    };
+
+    const getCategoryActiveOpacity = (categoryId) => {
+        if (
+            selectedCategoriesId.includes(categoryId) ||
+            selectedCategoriesId.length < 3
+        ) {
+            return 0;
+        } else {
+            return 1;
+        }
+    };
+
+    const renderCloseButton = () => (
+        <TouchableOpacity
+            style={styles.closeButton}
+            onPress={() => setModalVisible(false)}>
+            <Icon
+                name="times-circle"
+                type="font-awesome"
+                color={colors.danger}
+                size={30}
+            />
+        </TouchableOpacity>
+    );
+
+    const renderModalTitle = () => (
+        <>
+            <Text style={styles.title}>Escolha as categorias</Text>
+            <Text style={styles.subTitle}>(No máximo 3)</Text>
+        </>
+    );
+
+    const renderCategoryList = () => (
+        <ScrollView showsVerticalScrollIndicator={false}>
+            {categories?.map((category) => (
+                <TouchableOpacity
+                    activeOpacity={getCategoryActiveOpacity(category._id)}
+                    key={category._id}
+                    onPress={() => {
+                        selectCategory(category._id);
+                    }}>
+                    <Text style={getCategoryStyle(category._id)}>
+                        {category.name}
+                    </Text>
+                </TouchableOpacity>
+            ))}
+        </ScrollView>
+    );
+
     return (
-        <Modal visible transparent>
-            <TouchableOpacity style={styles.container}>
+        <Modal
+            visible={modalVisible}
+            transparent
+            onRequestClose={() => setModalVisible(false)}>
+            <TouchableOpacity style={styles.container} activeOpacity={1}>
                 <TouchableWithoutFeedback>
                     <View style={styles.content}>
-                        <Text style={styles.title}>Escolha as categorias</Text>
-                        <ScrollView showsVerticalScrollIndicator={false}>
-                            {categories?.map((category) => (
-                                <TouchableOpacity
-                                    key={category._id}
-                                    onPress={() => {
-                                        selectedCategoriesId.includes(
-                                            category._id,
-                                        )
-                                            ? removeCategory(category._id)
-                                            : selectCategory(category._id);
-                                    }}>
-                                    <Text
-                                        style={
-                                            selectedCategoriesId.includes(
-                                                category._id,
-                                            )
-                                                ? styles.selectedCategory
-                                                : styles.notSelectedCategory
-                                        }>
-                                        {category.name}
-                                    </Text>
-                                </TouchableOpacity>
-                            ))}
-                        </ScrollView>
+                        {renderCloseButton()}
+                        {renderModalTitle()}
+                        {renderCategoryList()}
                         <Button title="concluir" large type="warning" />
                     </View>
                 </TouchableWithoutFeedback>

--- a/app/src/components/modals/category/CategorySelector/styles.js
+++ b/app/src/components/modals/category/CategorySelector/styles.js
@@ -1,0 +1,47 @@
+import { StyleSheet, Dimensions } from 'react-native';
+const { height: screen_height } = Dimensions.get('window');
+import colors from '../../../../../assets/styles/colorVariables';
+import fonts from '../../../../../assets/styles/fontVariable';
+const styles = StyleSheet.create({
+    container: {
+        backgroundColor: 'rgba(0,0,0,0.3)',
+        width: '100%',
+        height: '100%',
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    content: {
+        paddingHorizontal: 20,
+        paddingVertical: 10,
+        width: '80%',
+        height: screen_height * 0.6,
+        backgroundColor: '#fff',
+        borderRadius: 10,
+    },
+    title: {
+        ...fonts.subtitle,
+        alignSelf: 'center',
+        marginBottom: 20,
+    },
+    notSelectedCategory: {
+        ...fonts.body,
+        borderWidth: 1,
+        padding: 8,
+        borderRadius: 5,
+        marginVertical: 5,
+        borderColor: colors.primary,
+        color: colors.primary,
+    },
+    selectedCategory: {
+        ...fonts.body,
+        borderWidth: 1,
+        padding: 8,
+        borderRadius: 5,
+        marginVertical: 5,
+        borderColor: colors.primary,
+        color: '#fff',
+        backgroundColor: colors.primary,
+    },
+});
+
+export default styles;

--- a/app/src/components/modals/category/CategorySelector/styles.js
+++ b/app/src/components/modals/category/CategorySelector/styles.js
@@ -21,7 +21,12 @@ const styles = StyleSheet.create({
     title: {
         ...fonts.subtitle,
         alignSelf: 'center',
-        marginBottom: 20,
+    },
+    subTitle: {
+        ...fonts.subtitle,
+        alignSelf: 'center',
+        fontSize: 14,
+        marginBottom: 10,
     },
     notSelectedCategory: {
         ...fonts.body,
@@ -32,6 +37,15 @@ const styles = StyleSheet.create({
         borderColor: colors.primary,
         color: colors.primary,
     },
+    unvailableToSelectCategory: {
+        ...fonts.body,
+        borderWidth: 1,
+        padding: 8,
+        borderRadius: 5,
+        marginVertical: 5,
+        borderColor: '#c4c4c4',
+        color: '#c4c4c4',
+    },
     selectedCategory: {
         ...fonts.body,
         borderWidth: 1,
@@ -41,6 +55,11 @@ const styles = StyleSheet.create({
         borderColor: colors.primary,
         color: '#fff',
         backgroundColor: colors.primary,
+    },
+    closeButton: {
+        position: 'absolute',
+        right: 10,
+        top: 5,
     },
 });
 

--- a/app/src/components/modals/category/categoryDescription/styles.js
+++ b/app/src/components/modals/category/categoryDescription/styles.js
@@ -17,6 +17,7 @@ const styles = StyleSheet.create({
     },
     title: {
         ...fonts.title,
+        fontSize: 20,
         alignSelf: 'center',
         marginBottom: 10,
         fontFamily: 'montserrat-semibold',

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -4,15 +4,18 @@ import { UserContextProvider } from './store/contexts/userContext';
 import HelpContextProvider from './store/contexts/helpContext';
 import CategoryContextProvider from './store/contexts/categoryContext';
 import DeviceInfoProvider from './store/contexts/deviceInformationContext';
+import HelpOfferContextProvider from './store/contexts/helpOfferContext';
 
 export default function Root() {
     return (
         <DeviceInfoProvider>
             <UserContextProvider>
                 <CategoryContextProvider>
-                    <HelpContextProvider>
-                        <Routes />
-                    </HelpContextProvider>
+                    <HelpOfferContextProvider>
+                        <HelpContextProvider>
+                            <Routes />
+                        </HelpContextProvider>
+                    </HelpOfferContextProvider>
                 </CategoryContextProvider>
             </UserContextProvider>
         </DeviceInfoProvider>

--- a/app/src/pages/AuthPages/PersonalData/index.js
+++ b/app/src/pages/AuthPages/PersonalData/index.js
@@ -35,7 +35,7 @@ export default function PersonalData({ route, navigation }) {
     const [cpf, setCPF] = useState('');
     const [cnpj, setCNPJ] = useState('');
     const [cellPhone, setCellPhone] = useState('');
-    const [mentalHealthProfessional, setMentalHealthProfessional] = useState(
+    const [ismentalHealthProfessional, setMentalHealthProfessional] = useState(
         false,
     );
     const [isEntityUser, setIsEntityUser] = useState(false);
@@ -83,7 +83,7 @@ export default function PersonalData({ route, navigation }) {
                 birthday: birthdayFormated,
                 cpf,
                 phone,
-                mentalHealthProfessional,
+                ismentalHealthProfessional,
                 ...userDatafromRegistrationPage,
             };
         }
@@ -223,14 +223,18 @@ export default function PersonalData({ route, navigation }) {
                         true: colors.primaryContrast,
                     }}
                     thumbColor={
-                        mentalHealthProfessional ? colors.primary : colors.light
+                        ismentalHealthProfessional
+                            ? colors.primary
+                            : colors.light
                     }
                     ios_backgroundColor={colors.dark}
                     onValueChange={() => {
-                        setMentalHealthProfessional(!mentalHealthProfessional);
+                        setMentalHealthProfessional(
+                            !ismentalHealthProfessional,
+                        );
                         setCNPJ('');
                     }}
-                    value={mentalHealthProfessional}
+                    value={ismentalHealthProfessional}
                 />
             </View>
         );

--- a/app/src/pages/AuthPages/RiskGroup/index.js
+++ b/app/src/pages/AuthPages/RiskGroup/index.js
@@ -112,11 +112,12 @@ export default function RiskGroup({ route, navigation }) {
                 {loadingUserRegistration ? (
                     renderLoadingIndicator()
                 ) : (
-                    <Button 
-                    disabled = {false}
-                    title="Concluir" 
-                    large 
-                    press={confirmSignUp} />
+                    <Button
+                        disabled={false}
+                        title="Concluir"
+                        large
+                        press={confirmSignUp}
+                    />
                 )}
             </View>
         </View>

--- a/app/src/pages/HelpPages/CreateHelpOffer/index.js
+++ b/app/src/pages/HelpPages/CreateHelpOffer/index.js
@@ -11,9 +11,7 @@ import { UserContext } from '../../../store/contexts/userContext';
 import useService from '../../../services/useService';
 import showWarningFor from '../../../utils/warningPopUp';
 import { requestHelpWarningMessage } from '../../../docs/warning';
-import CategorySelector from '../../../components/modals/category/CategorySelector';
-import { TouchableOpacity } from 'react-native-gesture-handler';
-import { CategoryContext } from '../../../store/contexts/categoryContext';
+import SelectCategoryForm from '../../../components/SelectCategoryForm';
 
 export default function CreateHelp({ navigation }) {
     const [helpOfferTitle, setHelpOfferTitle] = useState('');
@@ -23,14 +21,9 @@ export default function CreateHelp({ navigation }) {
     const [modalSuccessModalVisible, setModalSuccessMoldalVisible] = useState(
         false,
     );
-    const [categoryModalVisible, setCategoryModalVisible] = useState(false);
     const [createHelpOfferLoading, setCreateHelpOfferLoading] = useState(false);
 
     const { user } = useContext(UserContext);
-    const { categories } = useContext(CategoryContext);
-
-    const openCategoryModal = () => setCategoryModalVisible(true);
-    const hideCategoryModal = () => setCategoryModalVisible(false);
 
     useEffect(() => {
         showWarningFor('createHelp', requestHelpWarningMessage);
@@ -69,42 +62,6 @@ export default function CreateHelp({ navigation }) {
         setCreateHelpOfferLoading(false);
     }
 
-    const renderPickerCategoryForm = () => (
-        <TouchableOpacity
-            style={styles.addCategory}
-            onPress={openCategoryModal}>
-            <Text style={styles.addCategoryText}>Categorias +</Text>
-        </TouchableOpacity>
-    );
-
-    const renderSelectedCategories = () => {
-        return (
-            <View
-                style={{
-                    flexDirection: 'row',
-                    flexWrap: 'wrap',
-                    marginTop: 10,
-                }}>
-                {categories.map((category) => {
-                    if (helpOfferCategoryIds.includes(category._id)) {
-                        return (
-                            <Text
-                                style={{
-                                    backgroundColor: colors.secondary,
-                                    padding: 5,
-                                    elevation: 2,
-                                    margin: 5,
-                                    borderRadius: 2,
-                                }}>
-                                {category.name}
-                            </Text>
-                        );
-                    }
-                })}
-            </View>
-        );
-    };
-
     const renderInputDescriptionForm = () => (
         <View style={styles.descriptionInput}>
             <Input
@@ -138,19 +95,13 @@ export default function CreateHelp({ navigation }) {
     return (
         <ScrollView>
             <Container>
-                <CategorySelector
-                    modalVisible={categoryModalVisible}
-                    openModal={openCategoryModal}
-                    hideModal={hideCategoryModal}
-                    setHelpCategoryIds={setHelpOfferCategoryIds}
-                    categoryIds={helpOfferCategoryIds}
-                />
                 <View style={styles.view}>
                     {renderInputTitleForm()}
                     {renderInputDescriptionForm()}
-                    {renderPickerCategoryForm()}
-                    {renderSelectedCategories()}
-
+                    <SelectCategoryForm
+                        helpCategoryIds={helpOfferCategoryIds}
+                        setHelpCategoryIds={setHelpOfferCategoryIds}
+                    />
                     <View style={styles.btnContainer}>
                         {createHelpOfferLoading
                             ? renderLoadingIdicator()

--- a/app/src/pages/HelpPages/CreateHelpOffer/index.js
+++ b/app/src/pages/HelpPages/CreateHelpOffer/index.js
@@ -18,6 +18,7 @@ import { UserContext } from '../../../store/contexts/userContext';
 import useService from '../../../services/useService';
 import showWarningFor from '../../../utils/warningPopUp';
 import { requestHelpWarningMessage } from '../../../docs/warning';
+import CategorySelector from '../../../components/modals/category/CategorySelector';
 
 export default function CreateHelp({ navigation }) {
     const [helpOfferTitle, setHelpOfferTitle] = useState('');
@@ -121,6 +122,7 @@ export default function CreateHelp({ navigation }) {
     return (
         <ScrollView>
             <Container>
+                <CategorySelector />
                 <View style={styles.view}>
                     {renderInputTitleForm()}
                     {renderPickerCategoryForm()}

--- a/app/src/pages/HelpPages/CreateHelpOffer/index.js
+++ b/app/src/pages/HelpPages/CreateHelpOffer/index.js
@@ -101,6 +101,7 @@ export default function CreateHelp({ navigation }) {
                     <SelectCategoryForm
                         helpCategoryIds={helpOfferCategoryIds}
                         setHelpCategoryIds={setHelpOfferCategoryIds}
+                        helpType={'offer'}
                     />
                     <View style={styles.btnContainer}>
                         {createHelpOfferLoading

--- a/app/src/pages/HelpPages/CreateHelpOffer/styles.js
+++ b/app/src/pages/HelpPages/CreateHelpOffer/styles.js
@@ -52,6 +52,22 @@ const styles = StyleSheet.create({
     descriptionInput: {
         marginTop: 20,
     },
+    addCategory: {
+        backgroundColor: colors.primary,
+        borderWidth: 1,
+        borderColor: colors.primary,
+        padding: 5,
+        marginTop: 20,
+        width: '40%',
+        borderRadius: 5,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    addCategoryText: {
+        ...fonts.body,
+        color: '#fff',
+        fontSize: 18,
+    },
 });
 
 export default styles;

--- a/app/src/pages/HelpPages/CreateHelpOffer/styles.js
+++ b/app/src/pages/HelpPages/CreateHelpOffer/styles.js
@@ -52,22 +52,6 @@ const styles = StyleSheet.create({
     descriptionInput: {
         marginTop: 20,
     },
-    addCategory: {
-        backgroundColor: colors.primary,
-        borderWidth: 1,
-        borderColor: colors.primary,
-        padding: 5,
-        marginTop: 20,
-        width: '40%',
-        borderRadius: 5,
-        justifyContent: 'center',
-        alignItems: 'center',
-    },
-    addCategoryText: {
-        ...fonts.body,
-        color: '#fff',
-        fontSize: 18,
-    },
 });
 
 export default styles;

--- a/app/src/pages/HelpPages/CreateHelpRequest/index.js
+++ b/app/src/pages/HelpPages/CreateHelpRequest/index.js
@@ -1,18 +1,11 @@
 import React, { useState, useEffect, useContext } from 'react';
-import {
-    View,
-    TouchableOpacity,
-    Text,
-    ActivityIndicator,
-    ScrollView,
-} from 'react-native';
+import { View, Text, ActivityIndicator, ScrollView } from 'react-native';
 import styles from './styles';
 import Container from '../../../components/Container';
 import Input from '../../../components/UI/input';
 import Button from '../../../components/UI/button';
 import colors from '../../../../assets/styles/colorVariables';
-import { CategoryContext } from '../../../store/contexts/categoryContext';
-import CategorySelector from '../../../components/modals/category/CategorySelector';
+import SelectCategoryForm from '../../../components/SelectCategoryForm';
 
 import NewHelpModalSuccess from '../../../components/modals/newHelpModal/success';
 
@@ -30,14 +23,8 @@ export default function CreateHelp({ navigation }) {
     const [modalSuccessModalVisible, setModalSuccessMoldalVisible] = useState(
         false,
     );
-    const [categoryModalVisible, setCategoryModalVisible] = useState(false);
     const [createHelpLoading, setCreateHelpLoading] = useState(false);
-
-    const { categories } = useContext(CategoryContext);
     const { user } = useContext(UserContext);
-
-    const openCategoryModal = () => setCategoryModalVisible(true);
-    const hideCategoryModal = () => setCategoryModalVisible(false);
 
     useEffect(() => {
         showWarningFor('createHelp', requestHelpWarningMessage);
@@ -67,41 +54,6 @@ export default function CreateHelp({ navigation }) {
         setCreateHelpLoading(false);
     }
 
-    const renderPickerCategoryForm = () => (
-        <TouchableOpacity
-            style={styles.addCategory}
-            onPress={openCategoryModal}>
-            <Text style={styles.addCategoryText}>Categorias +</Text>
-        </TouchableOpacity>
-    );
-
-    const renderSelectedCategories = () => {
-        return (
-            <View
-                style={{
-                    flexDirection: 'row',
-                    flexWrap: 'wrap',
-                    marginTop: 10,
-                }}>
-                {categories.map((category) => {
-                    if (categoryIds.includes(category._id)) {
-                        return (
-                            <Text
-                                style={{
-                                    backgroundColor: colors.secondary,
-                                    padding: 5,
-                                    elevation: 2,
-                                    margin: 5,
-                                    borderRadius: 2,
-                                }}>
-                                {category.name}
-                            </Text>
-                        );
-                    }
-                })}
-            </View>
-        );
-    };
     const renderInputDescriptionForm = () => (
         <View style={styles.descriptionInput}>
             <Input
@@ -132,19 +84,13 @@ export default function CreateHelp({ navigation }) {
     return (
         <ScrollView>
             <Container>
-                <CategorySelector
-                    modalVisible={categoryModalVisible}
-                    openModal={openCategoryModal}
-                    hideModal={hideCategoryModal}
-                    setHelpCategoryIds={setCategoryIds}
-                    categoryIds={categoryIds}
-                />
                 <View style={styles.view}>
                     {renderInputTitleForm()}
                     {renderInputDescriptionForm()}
-                    {renderPickerCategoryForm()}
-                    {renderSelectedCategories()}
-
+                    <SelectCategoryForm
+                        helpCategoryIds={categoryIds}
+                        setHelpCategoryIds={setCategoryIds}
+                    />
                     <View style={styles.btnContainer}>
                         {createHelpLoading
                             ? renderLoadingIdicator()

--- a/app/src/pages/HelpPages/CreateHelpRequest/styles.js
+++ b/app/src/pages/HelpPages/CreateHelpRequest/styles.js
@@ -52,6 +52,22 @@ const styles = StyleSheet.create({
     descriptionInput: {
         marginTop: 20,
     },
+    addCategory: {
+        backgroundColor: colors.primary,
+        borderWidth: 1,
+        borderColor: colors.primary,
+        padding: 5,
+        marginTop: 20,
+        width: '40%',
+        borderRadius: 5,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    addCategoryText: {
+        ...fonts.body,
+        color: '#fff',
+        fontSize: 18,
+    },
 });
 
 export default styles;

--- a/app/src/pages/HelpPages/MapHelpDescription/index.js
+++ b/app/src/pages/HelpPages/MapHelpDescription/index.js
@@ -81,10 +81,14 @@ export default function MapHelpDescription({ route, navigation }) {
         <View style={styles.helpInfo}>
             <View style={styles.helpInfoText}>
                 <Text style={styles.titleFont}>{help.title}</Text>
-                <View style={styles.categoryWarning}>
-                    <Text style={styles.categoryName}>
-                        {help.category[0].name}
-                    </Text>
+                <View style={styles.categoryContainer}>
+                    {help.categories.map((category) => (
+                        <View key={category._id} style={styles.categoryWarning}>
+                            <Text style={styles.categoryName}>
+                                {category.name}
+                            </Text>
+                        </View>
+                    ))}
                 </View>
                 <Text style={[styles.infoText, styles.infoTextBottom]}>
                     {help.description}

--- a/app/src/pages/HelpPages/MapHelpDescription/styles.js
+++ b/app/src/pages/HelpPages/MapHelpDescription/styles.js
@@ -61,6 +61,8 @@ const styles = StyleSheet.create({
 
         paddingHorizontal: 15,
         alignSelf: 'center',
+        marginLeft: 5,
+        marginTop: 5,
     },
 
     categoryName: {
@@ -69,6 +71,13 @@ const styles = StyleSheet.create({
         lineHeight: 30,
         textAlign: 'center',
         alignSelf: 'center',
+    },
+    categoryContainer: {
+        flexDirection: 'row',
+        width: '100%',
+        marginVertical: 15,
+        justifyContent: 'center',
+        flexWrap: 'wrap',
     },
 });
 

--- a/app/src/pages/HelpPages/MyOfferHelpDescription/index.js
+++ b/app/src/pages/HelpPages/MyOfferHelpDescription/index.js
@@ -144,10 +144,14 @@ export default function MyOfferHelpDescription({ route, navigation }) {
         <View style={styles.helpInfo}>
             <View style={styles.helpInfoText}>
                 <Text style={styles.titleFont}>{help.title}</Text>
-                <View style={styles.categoryWarning}>
-                    <Text style={styles.categoryName}>
-                        {help.category[0].name}
-                    </Text>
+                <View style={styles.categoryContainer}>
+                    {help.categories.map((category) => (
+                        <View key={category._id} style={styles.categoryWarning}>
+                            <Text style={styles.categoryName}>
+                                {category.name}
+                            </Text>
+                        </View>
+                    ))}
                 </View>
                 <Text style={[styles.infoText, styles.infoTextBottom]}>
                     {help.description}

--- a/app/src/pages/HelpPages/MyOfferHelpDescription/styles.js
+++ b/app/src/pages/HelpPages/MyOfferHelpDescription/styles.js
@@ -75,6 +75,8 @@ const styles = StyleSheet.create({
 
         paddingHorizontal: 15,
         alignSelf: 'center',
+        marginLeft: 5,
+        marginTop: 5,
     },
 
     categoryName: {
@@ -83,6 +85,13 @@ const styles = StyleSheet.create({
         lineHeight: 30,
         textAlign: 'center',
         alignSelf: 'center',
+    },
+    categoryContainer: {
+        flexDirection: 'row',
+        width: '100%',
+        marginVertical: 15,
+        justifyContent: 'center',
+        flexWrap: 'wrap',
     },
 });
 

--- a/app/src/pages/HelpPages/MyRequestHelpDescrition/index.js
+++ b/app/src/pages/HelpPages/MyRequestHelpDescrition/index.js
@@ -12,7 +12,7 @@ export default function HelpDescription({ route, navigation }) {
     const { user } = useContext(UserContext);
 
     const { help } = route.params;
-
+    console.log(help.categories);
     const userProfilephoto = help.user.photo || user.photo;
 
     const renderPossibleHelpersButton = () => (
@@ -66,10 +66,14 @@ export default function HelpDescription({ route, navigation }) {
         <View style={styles.helpInfo}>
             <View style={styles.helpInfoText}>
                 <Text style={styles.titleFont}>{help.title}</Text>
-                <View style={styles.categoryWarning}>
-                    <Text style={styles.categoryName}>
-                        {help.category[0].name}
-                    </Text>
+                <View style={styles.categoryContainer}>
+                    {help.categories.map((category) => (
+                        <View key={category._id} style={styles.categoryWarning}>
+                            <Text style={styles.categoryName}>
+                                {category.name}
+                            </Text>
+                        </View>
+                    ))}
                 </View>
                 <Text style={[styles.infoText, styles.infoTextBottom]}>
                     {help.description}

--- a/app/src/pages/HelpPages/MyRequestHelpDescrition/index.js
+++ b/app/src/pages/HelpPages/MyRequestHelpDescrition/index.js
@@ -12,7 +12,6 @@ export default function HelpDescription({ route, navigation }) {
     const { user } = useContext(UserContext);
 
     const { help } = route.params;
-    console.log(help.categories);
     const userProfilephoto = help.user.photo || user.photo;
 
     const renderPossibleHelpersButton = () => (

--- a/app/src/pages/HelpPages/MyRequestHelpDescrition/styles.js
+++ b/app/src/pages/HelpPages/MyRequestHelpDescrition/styles.js
@@ -93,11 +93,11 @@ const styles = StyleSheet.create({
     categoryWarning: {
         backgroundColor: colors.secondary,
         borderRadius: 8,
-
         maxHeight: 30,
-
         paddingHorizontal: 15,
         alignSelf: 'center',
+        marginLeft: 5,
+        marginTop: 5,
     },
 
     categoryName: {
@@ -106,6 +106,13 @@ const styles = StyleSheet.create({
         lineHeight: 30,
         textAlign: 'center',
         alignSelf: 'center',
+    },
+    categoryContainer: {
+        flexDirection: 'row',
+        width: '100%',
+        marginVertical: 15,
+        justifyContent: 'center',
+        flexWrap: 'wrap',
     },
 });
 

--- a/app/src/pages/Main/index.js
+++ b/app/src/pages/Main/index.js
@@ -9,6 +9,7 @@ import CreateHelpButtons from '../../components/CreateHelpButtons';
 import CategoryListModal from '../../components/modals/category/CategoryList';
 import { HelpContext } from '../../store/contexts/helpContext';
 import { UserContext } from '../../store/contexts/userContext';
+// import { HelpOfferContext } from '../../store/contexts/helpOfferContext';
 import HelpList from '../../components/HelpList';
 import UserMarker from './UserMarker';
 import HelpMarker from './HelpMarker';
@@ -19,6 +20,7 @@ export default function Main({ navigation }) {
     const [filterModalVisible, setFilterModalVisible] = useState(false);
     const { helpList } = useContext(HelpContext);
     const { userPosition } = useContext(UserContext);
+    // const { helpOfferList } = useContext(HelpOfferContext);
 
     useEffect(() => {
         setRegion(null);

--- a/app/src/services/Help.js
+++ b/app/src/services/Help.js
@@ -51,10 +51,10 @@ class HelpService {
         const createdHelpResponse = await api.post('/help', data);
         return createdHelpResponse.data;
     }
-    async createHelpOffer(title, categoryIds, description, ownerId) {
+    async createHelpOffer(title, categoryId, description, ownerId) {
         const data = {
             title,
-            categoryIds,
+            categoryId,
             description,
             ownerId,
         };

--- a/app/src/services/Help.js
+++ b/app/src/services/Help.js
@@ -51,10 +51,10 @@ class HelpService {
         const createdHelpResponse = await api.post('/help', data);
         return createdHelpResponse.data;
     }
-    async createHelpOffer(title, categoryId, description, ownerId) {
+    async createHelpOffer(title, categoryIds, description, ownerId) {
         const data = {
             title,
-            categoryId,
+            categoryIds,
             description,
             ownerId,
         };

--- a/app/src/services/Help.js
+++ b/app/src/services/Help.js
@@ -63,6 +63,11 @@ class HelpService {
         return createdHelpResponse.data;
     }
 
+    async listHelpOffer() {
+        const helpOfferList = await api.get('/helpOffer/list');
+        return helpOfferList.data;
+    }
+
     async deleteHelp(helpId) {
         const deleteHelp = await api.delete(`/help/${helpId}`);
         return deleteHelp;

--- a/app/src/store/contexts/helpOfferContext.js
+++ b/app/src/store/contexts/helpOfferContext.js
@@ -1,0 +1,35 @@
+import React, { useEffect, useContext, createContext, useState } from 'react';
+import { UserContext } from './userContext';
+
+import useService from '../../services/useService';
+import HelpService from '../../services/Help';
+
+export const HelpOfferContext = createContext();
+
+export default function HelpOfferContextProvider({ children }) {
+    const { user } = useContext(UserContext);
+    const [helpOfferList, setHelpOfferList] = useState([]);
+
+    useEffect(() => {
+        const isUserAuhtenticated = user._id;
+        if (isUserAuhtenticated) {
+            getHelpOfferList();
+        }
+    }, [user]);
+
+    async function getHelpOfferList() {
+        const helpOfferListResponse = await useService(
+            HelpService,
+            'listHelpOffer',
+        );
+        if (!helpOfferListResponse.error) {
+            setHelpOfferList(helpOfferListResponse);
+        }
+    }
+
+    return (
+        <HelpOfferContext.Provider value={{ helpOfferList }}>
+            {children}
+        </HelpOfferContext.Provider>
+    );
+}


### PR DESCRIPTION
## Descrição 

Foi criado as páginas e lógicas para a adição de mais de uma categoria em uma oferta/pedido de ajuda. Agora, pode-se criar mais de uma categoria para uma ajuda; Limite de 3 categorias;

## Resolve (Issues)
[#118](https://github.com/mia-ajuda/Documentation/issues/118) - Categorizar ofertas

## PRs relacionados, se houver

branch | PR
118-helpCategory (Backend) | [#77](https://github.com/mia-ajuda/Backend/pull/77)

## Tarefas gerais realizadas
* Criação do modal para selecionar mais de uma categoria na oferta de ajuda;
* Criação do modal para selecionar mais de uma categoria no pedido de ajuda;
* Adição das labels de multiplas categorias nos cards e na página de descrição das ajudas; 

Teste: 
 - Suba o backend na branch 118-HelpCategory;
- No frontend use a brach 118-HelpCategory, crie uma oferta de ajuda e uma ajuda. Selecione mais de uma categoria;
- No app, na página de meus pedidos, verifique se sua ajuda foi criada e se possui mais de uma categoria;
- Obs, testar, também o filtro por categoria no mapa; 
