### PR TITLE
 Fixed multiple requisitions to backend when filter categories

### DIFF
--- a/app/src/components/modals/category/CategoryList/index.js
+++ b/app/src/components/modals/category/CategoryList/index.js
@@ -29,6 +29,7 @@ export default function CategoryList({
         categories,
         setSelectedCategories,
         selectedCategories,
+        setFilterCategories,
     } = useContext(CategoryContext);
     const [selectedMarkerType, setSelectedMarkerType] = useState([]);
 
@@ -41,7 +42,6 @@ export default function CategoryList({
         );
         setSelectedCategories(removeCategoryId);
     };
-
     const getCategoryActiveOpacity = (categoryId) => {
         if (
             selectedCategories.includes(categoryId) ||
@@ -74,6 +74,7 @@ export default function CategoryList({
     async function filterHelplist() {
         setSelectedCategories(selectedCategories);
         setSelectedMarker(selectedMarkerType);
+        setFilterCategories(true);
         setVisible(!visible);
     }
     async function clearFilterHelplist() {

--- a/app/src/store/contexts/categoryContext.js
+++ b/app/src/store/contexts/categoryContext.js
@@ -9,6 +9,7 @@ export default function CategoryContextProvider(props) {
     const [categories, setCategories] = useState([]);
     const { user } = useContext(UserContext);
     const [selectedCategories, setSelectedCategories] = useState([]);
+    const [filterCategories, setFilterCategories] = useState(false);
 
     useEffect(() => {
         const isUserAuthenticated = user._id;
@@ -24,7 +25,13 @@ export default function CategoryContextProvider(props) {
 
     return (
         <CategoryContext.Provider
-            value={{ categories, selectedCategories, setSelectedCategories }}>
+            value={{
+                categories,
+                selectedCategories,
+                setSelectedCategories,
+                filterCategories,
+                setFilterCategories,
+            }}>
             {props.children}
         </CategoryContext.Provider>
     );

--- a/app/src/store/contexts/helpContext.js
+++ b/app/src/store/contexts/helpContext.js
@@ -111,6 +111,7 @@ export default function HelpContextProvider(props) {
                     helps: helpListFiltered,
                 });
             }
+            setFilterCategories(false);
         }
     }
 

--- a/app/src/store/contexts/helpContext.js
+++ b/app/src/store/contexts/helpContext.js
@@ -21,7 +21,11 @@ import {
 export const HelpContext = createContext();
 
 export default function HelpContextProvider(props) {
-    const { selectedCategories } = useContext(CategoryContext);
+    const {
+        selectedCategories,
+        filterCategories,
+        setFilterCategories,
+    } = useContext(CategoryContext);
     const { user, userPosition } = useContext(UserContext);
     const [helpList, dispatch] = useReducer(helpReducer, []);
     const [loadingHelps, setLoadingHelps] = useState(false);
@@ -69,6 +73,7 @@ export default function HelpContextProvider(props) {
                 getHelpListWithCategories(userPosition);
             } else {
                 getHelpList(userPosition);
+                setFilterCategories(false);
             }
             changeCategories(selectedCategories);
         }
@@ -93,7 +98,7 @@ export default function HelpContextProvider(props) {
     }
 
     async function getHelpListWithCategories(coords) {
-        if (coords && selectedCategories.length) {
+        if (coords && selectedCategories.length && filterCategories) {
             const { _id: userId } = user;
             const helpListFiltered = await useService(
                 HelpService,


### PR DESCRIPTION
## Descrição 

Quando o usuário filtrava ajudas, o app fazia múltiplas requisições desnecessárias para o backend, podendo acarretar em um problema de sobrecarga no futuro. 