### PR TITLE
Adaptação do Interceptor

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -28,6 +28,7 @@
         "expo-image-picker": "~8.3.0",
         "expo-location": "~8.2.1",
         "firebase": "7.9.0",
+        "jwt-decode": "^3.1.2",
         "logkitty": "^0.7.1",
         "moment": "^2.24.0",
         "moment-timezone": "^0.5.28",

--- a/app/src/services/Api.js
+++ b/app/src/services/Api.js
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { AsyncStorage } from 'react-native';
 import ENV from '../config/envVariables';
 import firebaseService from './Firebase';
+import jwt_decode from 'jwt-decode';
 
 const api = axios.create({
     baseURL: ENV.apiUrl,
@@ -9,34 +10,24 @@ const api = axios.create({
 
 api.interceptors.request.use(
     async (config) => {
-        const accessToken = await AsyncStorage.getItem('accessToken');
+        let accessToken = await AsyncStorage.getItem('accessToken');
+
+        if (accessToken) {
+            const expireDate = jwt_decode(accessToken).exp;
+            const now = Date.now() / 1000;
+
+            if (now > expireDate) {
+                const newToken = await firebaseService.getUserId();
+                await AsyncStorage.setItem('accessToken', newToken);
+                accessToken = newToken;
+            }
+        }
+
         config.headers.Authorization = `Bearer ${accessToken}`;
         return config;
     },
     (error) => {
         console.log(error);
-    },
-);
-
-api.interceptors.response.use(
-    (response) => {
-        return response;
-    },
-    async (error) => {
-        const originalRequest = error.config;
-        if (error.response != undefined) {
-            if (error.response.status === 401) {
-                const correctRequest = await firebaseService
-                    .getUserId()
-                    .then(async (idTokenUser) => {
-                        await AsyncStorage.setItem('accessToken', idTokenUser);
-                        originalRequest.headers.Authorization = `Bearer ${idTokenUser}`;
-                        return await axios(originalRequest);
-                    });
-                return correctRequest;
-            }
-        }
-        throw error;
     },
 );
 


### PR DESCRIPTION
## Descrição 

Em um projeto percebi que a informação da expiração do token do firebase era guardado no payload do próprio token. Isso possibilita verificar o vencimento do token antes de qualquer request e assim evitar que o request falhe para pedir um novo token. Já que o mia ajuda também utiliza o firebase, fiz essa alteração por aqui tbm. 

## Tarefas gerais realizadas
* Instalação da biblioteca jwt-decode para decodificar o token do firebase
* Checagem se o token está expirado antes de realizar a requisição. A tarefa de decodificar um token não tem um custo computacional alto por isso não há prejuízo de performance. 
* renovação do token caso o mesmo esteja vencido. 

Essa alteração evita que a requisição tenha que dar erro 403 para que o token seja renovado limpa um pouco do código no serviço da api. 
