### PR TITLE
Bugfix login persistence

### DIFF
--- a/app/src/Navigation/MainNavigation/BottomNavigator/index.js
+++ b/app/src/Navigation/MainNavigation/BottomNavigator/index.js
@@ -1,10 +1,8 @@
 import React, { useContext } from 'react';
-import { HelpContext } from '../../../store/contexts/helpContext';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import MapNavigation from '../MapStackNavigator';
 import ProfileNavigation from '../ProfileNavigator';
 import OngActivitiesNavigator from '../OngActivitiesNavigator';
-import Splash from '../../../pages/Splash';
 import navigationIconsConfig from './navigationIcons.options';
 import navigationOptions from './BottomNavigator.options';
 import FAQNavigator from '../FAQNavigator';
@@ -14,10 +12,8 @@ import ActivitiesNavigator from '../ActivitiesNavigator';
 
 const BottomNavigation = createBottomTabNavigator();
 const BottomTab = () => {
-    const { loadingHelps } = useContext(HelpContext);
     const { user } = useContext(UserContext);
     const isEntity = !!user.cnpj;
-    if (loadingHelps) return <Splash />;
 
     return (
         <BottomNavigation.Navigator

--- a/app/src/Navigation/index.js
+++ b/app/src/Navigation/index.js
@@ -3,14 +3,16 @@ import BottomTab from './MainNavigation/BottomNavigator';
 import AuthRoutes from './AuthNavigation';
 import { NavigationContainer } from '@react-navigation/native';
 import { UserContext } from '../store/contexts/userContext';
+import { HelpContext } from '../store/contexts/helpContext';
 import Splash from '../pages/Splash';
 
 const Routes = () => {
     const { user } = useContext(UserContext);
+    const { loadingHelps } = useContext(HelpContext);
     const isLoadingUserInformation = user && user.showSplash;
     const isUserAuthenticated = user._id;
 
-    if (isLoadingUserInformation) {
+    if (isLoadingUserInformation || (isUserAuthenticated && loadingHelps)) {
         return <Splash />;
     }
 

--- a/app/src/store/contexts/userContext.js
+++ b/app/src/store/contexts/userContext.js
@@ -18,12 +18,7 @@ export const UserContextProvider = (props) => {
     const [user, dispatch] = useReducer(userReducer, {
         showSplash: true,
     });
-    const [userPosition, setUserPosition] = useState({
-        latitude: 0,
-        longitude: 0,
-        latitudeDelta: 0.025,
-        longitudeDelta: 0.025,
-    });
+    const [userPosition, setUserPosition] = useState(null);
 
     useEffect(() => {
         setFirebaseTokenListener();
@@ -31,7 +26,7 @@ export const UserContextProvider = (props) => {
 
     useEffect(() => {
         async function getLocation() {
-            await AsyncStorage.clear();
+            //await AsyncStorage.clear();
             const { granted } = await requestPermissionsAsync();
             if (granted) {
                 const { coords } = await getCurrentPositionAsync({


### PR DESCRIPTION
## Descrição 

O login do usúario não estava persistindo ao se fechar e abrir o app, dessa foma, sempre que o usúario abria o app era necessário efetuar o login novamente.

## Resolve (Issues)

[#164](https://github.com/mia-ajuda/Documentation/issues/164)

## Tarefas gerais realizadas
* Foi removida uma limpeza do asyncStorage que estava ocorrendo sempre que o usúario logava(ou tentava logar através da splash)
* Foi removida a responsabilidade de mostrar a Splash do Bottom Navigation e levada para o componente Navigation (como o Navigation já mostrava a Splash em alguns casos e a BottomNav em outros, o app navagava entre a Main e a Splash algumas vezes antes de entrar de vez no app)
