### PR TITLE
US43: Deletando oferta de ajuda do mapa pelo socket

### DIFF
--- a/app/src/services/socket.js
+++ b/app/src/services/socket.js
@@ -15,6 +15,11 @@ function subscribeToDeleteHelp(subscribeFunction) {
     socket.on('delete-help', subscribeFunction);
 }
 
+function subscribeToDeleteHelpOffer(subscribeFunction) {
+    socket.off('delete-help-offer');
+    socket.on('delete-help-offer', subscribeFunction);
+}
+
 function connect(userPosition, userId) {
     socket.io.opts.query = {
         userPosition,
@@ -38,5 +43,6 @@ export {
     disconnect,
     subscribeToNewHelps,
     subscribeToDeleteHelp,
+    subscribeToDeleteHelpOffer,
     changeCategories,
 };

--- a/app/src/store/contexts/helpOfferContext.js
+++ b/app/src/store/contexts/helpOfferContext.js
@@ -1,9 +1,9 @@
 import React, { useEffect, useContext, createContext, useState } from 'react';
 import { UserContext } from './userContext';
 import { CategoryContext } from './categoryContext';
-
 import useService from '../../services/useService';
 import HelpService from '../../services/Help';
+import { subscribeToDeleteHelpOffer } from '../../services/socket';
 
 export const HelpOfferContext = createContext();
 
@@ -29,6 +29,16 @@ export default function HelpOfferContextProvider({ children }) {
             }
         }
     }, [selectedCategories]);
+
+    useEffect(() => {
+        subscribeToDeleteHelpOffer((helpOfferId) =>
+            setHelpOfferList((helpOfferList) =>
+                helpOfferList.filter(
+                    (helpOffer) => helpOffer._id != helpOfferId,
+                ),
+            ),
+        );
+    }, []);
 
     async function getHelpOfferList() {
         const helpOfferListResponse = await useService(

--- a/app/src/store/contexts/helpOfferContext.js
+++ b/app/src/store/contexts/helpOfferContext.js
@@ -32,8 +32,8 @@ export default function HelpOfferContextProvider({ children }) {
 
     useEffect(() => {
         subscribeToDeleteHelpOffer((helpOfferId) =>
-            setHelpOfferList((helpOfferList) =>
-                helpOfferList.filter(
+            setHelpOfferList((currentValue) =>
+                currentValue.filter(
                     (helpOffer) => helpOffer._id != helpOfferId,
                 ),
             ),


### PR DESCRIPTION
## Descrição 
Foi implementado a exclusão de ofertas de ajuda do mapa em tempo real por meio do subscribe do socket. 

## Resolve (Issues)
- https://github.com/mia-ajuda/Documentation/issues/123

## Testar
- Crie uma oferta
- Entre em uma conta diferente
- Localize a oferta
- Exclua a oferta enquanto visualiza de uma conta diferente da dona.
- A oferta some sem precisar atualizar o mapa

## PRs relacionados

branch | PR
------ | ------
US43-delete_help_offer_socket | https://github.com/mia-ajuda/Backend/pull/114

## Tarefas gerais realizadas
* As ofertas agora são apagadas em tempo real do mapa por meio do socket

