### PR TITLE
209-Mostrar data de criação de pedido, oferta e campanha

### DIFF
--- a/app/src/pages/HelpPages/CampaignDescription/index.js
+++ b/app/src/pages/HelpPages/CampaignDescription/index.js
@@ -17,15 +17,15 @@ import useService from '../../../services/useService';
 import { alertSuccess } from '../../../utils/Alert';
 import CampaignService from '../../../services/Campaign';
 import Button from '../../../components/UI/button';
+import getBRDateFromString from '../../../utils/getBRDateFromString';
 
 export default function CampaignDescription({ route, navigation }) {
     const { campaign } = route.params;
     const { user } = useContext(UserContext);
     const campaignOwnerPhoto = campaign.entity.photo;
     const [finishCampaignLoading, setFinishCampaignLoading] = useState(false);
-    const [confirmationModalVisible, setConfirmationModalVisible] = useState(
-        false,
-    );
+    const [confirmationModalVisible, setConfirmationModalVisible] =
+        useState(false);
     const isTheSameUser = user._id === campaign.ownerId;
     const goBackToMyResquestsPage = () => navigation.goBack();
 
@@ -113,6 +113,12 @@ export default function CampaignDescription({ route, navigation }) {
                     <Text style={styles.infoText}>
                         <Text style={styles.infoTextFont}>Telefone: </Text>
                         {campaign.entity.phone}
+                    </Text>
+                    <Text style={styles.infoText}>
+                        <Text style={styles.infoTextFont}>
+                            Data de criação:{' '}
+                        </Text>
+                        {getBRDateFromString(campaign.creationDate)}
                     </Text>
                 </View>
             </View>

--- a/app/src/pages/HelpPages/MapHelpDescription/index.js
+++ b/app/src/pages/HelpPages/MapHelpDescription/index.js
@@ -16,6 +16,7 @@ import shortenName from '../../../utils/shortenName';
 import messageOperation from '../../../utils/messageOperation';
 
 import colors from '../../../../assets/styles/colorVariables';
+import getBRDateFromString from '../../../utils/getBRDateFromString';
 
 export default function MapHelpDescription({ route, navigation }) {
     const { help, helpType } = route.params;
@@ -114,6 +115,10 @@ export default function MapHelpDescription({ route, navigation }) {
                     <Text style={styles.infoText}>
                         <Text style={styles.infoTextFont}>Cidade: </Text>
                         {ownerInfo.address.city}
+                    </Text>
+                    <Text style={styles.infoText}>
+                        <Text style={styles.infoTextFont}>Criada em: </Text>
+                        {getBRDateFromString(help.creationDate)}
                     </Text>
                 </View>
             </View>

--- a/app/src/utils/getBRDateFromString.js
+++ b/app/src/utils/getBRDateFromString.js
@@ -1,0 +1,5 @@
+const getBRDateFromString = (string) => {
+    var date = new Date(string);
+    return date.toLocaleDateString('pt-BR');
+};
+export default getBRDateFromString;


### PR DESCRIPTION
## Descrição 

Adição do campo "data de criação" nas telas de descrição de pedido, oferta e campanha

## Resolve (Issues)

[209](https://github.com/mia-ajuda/Documentation/issues/209)

## PRs relacionados, se houver

branch | PR
------ | ------
209-ShowOfferDate | [Backend 209](https://github.com/mia-ajuda/Backend/pull/126)

## Tarefas gerais realizadas
* Adição de um novo campo de data de criação
