### PR TITLE
fix: add condition to check if password is equal to confirm password

### DIFF
--- a/app/src/pages/AuthPages/RegistrationData/index.js
+++ b/app/src/pages/AuthPages/RegistrationData/index.js
@@ -147,7 +147,8 @@ export default function RegistrationData({ navigation }) {
         const fieldsValid =
             emailValidator(email) &&
             passwordValidator(password) &&
-            passwordValidator(confirmPassword);
+            passwordValidator(confirmPassword) &&
+            password == confirmPassword;
 
         return (
             <Button


### PR DESCRIPTION
## Descrição 

Adicionar condicional que verifica se a senha é igual à confirmação da senha, se for ele libera o botão de continuar. Antes o botão estava renderizando mesmo com os campos tendo senhas diferentes.
## Resolve (Issues)

## PRs relacionados, se houver

branch | PR
HOTFIX-confirm-password-validation | [https://github.com/mia-ajuda/Frontend/compare/HOTFIX-confirm-password-validation?expand=1](fix: add condition to check if password is equal to confirm password)
outro_pr_relacionado | [link]()

## Tarefas gerais realizadas
* Validar se a senha é igual a confirmação de senha
