### PR TITLE
Mostrando string em branco caso pedido não tenha Index

### DIFF
--- a/app/src/components/modals/ActivityBottomSheet/UserActivity/index.jsx
+++ b/app/src/components/modals/ActivityBottomSheet/UserActivity/index.jsx
@@ -14,6 +14,7 @@ import { BadgeContext } from '../../../../store/contexts/badgeContext';
 import { LoadingContext } from '../../../../store/contexts/loadingContext';
 import { UserContext } from '../../../../store/contexts/userContext';
 import { Dialog } from '../../../molecules/Dialog';
+import { translatedActivities } from '../../../../utils/translatedActivities';
 
 export const UserActivity = ({
     activityType,
@@ -31,6 +32,7 @@ export const UserActivity = ({
         useState(false);
 
     const activityIcon = getActivityIcon(activityType);
+    const activity = translatedActivities[activityType].translation;
     const indicatorColor = isRiskGroup
         ? { icon: colors.danger[300], text: 'text-danger-300' }
         : { icon: colors.primary[300], text: 'text-primary-300' };
@@ -97,7 +99,7 @@ export const UserActivity = ({
                 <Text
                     className={`${indicatorColor.text} font-ms-semibold text-2xl ml-2`}
                 >
-                    Pedido
+                    {activity}
                 </Text>
             </View>
             <View className="justify-center">

--- a/app/src/components/molecules/ActivityMarker/index.jsx
+++ b/app/src/components/molecules/ActivityMarker/index.jsx
@@ -66,7 +66,7 @@ export const ActivityMarker = ({
                     } overflow-hidden `}
                     numberOfLines={1}
                 >
-                    {title || `${selectedType.text} ${index}`}
+                    {title || `${selectedType.text} ${index || ''}`}
                 </Text>
             </View>
         </Marker>

--- a/app/src/components/organisms/ActivityCard/index.jsx
+++ b/app/src/components/organisms/ActivityCard/index.jsx
@@ -13,6 +13,7 @@ import { ActivityBottomSheetContext } from '../../../store/contexts/activityBott
 import navigateToMyActivity from '../../../utils/navigateToMyActivity';
 import { ActivitiesContext } from '../../../store/contexts/activitiesContext';
 import colors from '../../../../colors';
+import { translatedActivities } from '../../../utils/translatedActivities';
 
 export const ActivityCard = ({
     variant,
@@ -34,18 +35,7 @@ export const ActivityCard = ({
     const isNewActivity = isRecentDate(creationDate);
     const isTheSameUser = user._id == ownerId;
 
-    const activitiesVariants = {
-        help: {
-            translation: 'Pedido',
-        },
-        offer: {
-            translation: 'Oferta',
-        },
-        campaign: {
-            translation: 'Campanha',
-        },
-    };
-    const selectedVariant = activitiesVariants[variant];
+    const selectedVariant = translatedActivities[variant].translation;
     const icon = getActivityIcon(variant);
     const color = {
         font: isRiskGroup ? 'text-danger' : 'text-primary-400',
@@ -87,7 +77,7 @@ export const ActivityCard = ({
                     type={icon.type}
                 />
                 <Text className={`${color.font} font-ms-bold ml-1 text-base`}>
-                    {`${selectedVariant.translation} ${count || ''}`}
+                    {`${selectedVariant} ${count || ''}`}
                 </Text>
                 {isNewActivity && <SeedlingIcon className="ml-auto" />}
             </View>

--- a/app/src/components/organisms/ActivityCard/index.jsx
+++ b/app/src/components/organisms/ActivityCard/index.jsx
@@ -87,7 +87,7 @@ export const ActivityCard = ({
                     type={icon.type}
                 />
                 <Text className={`${color.font} font-ms-bold ml-1 text-base`}>
-                    {`${selectedVariant.translation} ${count}`}
+                    {`${selectedVariant.translation} ${count || ''}`}
                 </Text>
                 {isNewActivity && <SeedlingIcon className="ml-auto" />}
             </View>

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -43,7 +43,7 @@ export default function Root() {
                         </SocialNetworkProfileContextProvider>
                     </UserContextProvider>
                 </LoadingContextProvider>
-            </DeviceInfoProvider >
+            </DeviceInfoProvider>
         </>
     );
 }

--- a/app/src/pages/TimeLine/index.jsx
+++ b/app/src/pages/TimeLine/index.jsx
@@ -45,8 +45,16 @@ export const Timeline = () => {
 
     return (
         <View className="bg-new_background flex-1 px-4 py-6">
-            {hasTimelineItems && <DefaultTimeline data={parsedTimelineItems} useIcon />}
-            {!hasTimelineItems && <NotFound size='large' title='Possivelmente você é dev' body='Se você está vendo isso é porque criou a conta antes dessa feat e não atualizou seu banco de dados'/>}
+            {hasTimelineItems && (
+                <DefaultTimeline data={parsedTimelineItems} useIcon />
+            )}
+            {!hasTimelineItems && (
+                <NotFound
+                    size="large"
+                    title="Possivelmente você é dev"
+                    body="Se você está vendo isso é porque criou a conta antes dessa feat e não atualizou seu banco de dados"
+                />
+            )}
         </View>
     );
 };

--- a/app/src/utils/translatedActivities.js
+++ b/app/src/utils/translatedActivities.js
@@ -1,0 +1,11 @@
+export const translatedActivities = {
+    help: {
+        translation: 'Pedido',
+    },
+    offer: {
+        translation: 'Oferta',
+    },
+    campaign: {
+        translation: 'Campanha',
+    },
+};


### PR DESCRIPTION
## Descrição 
Como foi removida a função que mapeava todas as atividades para adicionar o index coloquei um safe guard para garantir que se por algum motivo o index não for retornado ele colocar uma string vazia ao invés de undefined.

## PRs relacionados, se houver

branch | PR
------ | ------
fix/wrong-helpoffer-return | [HOTFIX - Tela de minhas ofertas quebrando](https://github.com/mia-ajuda/Backend/pull/162)

## Tarefas gerais realizadas
* Adição de || com string vazia
