### PR TITLE
HOTFIX - Evitar app quebrar quando o usuário está nulo

### DIFF
--- a/app/src/services/Firebase.js
+++ b/app/src/services/Firebase.js
@@ -30,7 +30,7 @@ class FirebaseService {
     }
 
     async getUserId() {
-        return await this.firebase.auth().currentUser.getIdToken();
+        return await this.firebase.auth().currentUser?.getIdToken();
     }
     async getCurrentUser() {
         return this.firebase.auth().currentUser;


### PR DESCRIPTION
## Descrição 
Aplicativo estava dando erro quando o token do usuário expirava.

## Resolve (Issues)
Adiciona um safe operator para evitar tentar acesso a um usuário inexistente.


## Tarefas gerais realizadas
* Adição do safe operator antes de buscar o token.
